### PR TITLE
feat: implement autoscrolling during drag and drop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   unit-tests:

--- a/.github/workflows/pr-previews.yml
+++ b/.github/workflows/pr-previews.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Deploy to Firebase Hosting Preview Channel
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           projectId: todo-firebase-1a740

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check for Firebase Service Account Secret
         id: check_secret
         env:
-          FIREBASE_SERVICE_ACCOUNT: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          FIREBASE_SERVICE_ACCOUNT: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
         run: |
           if [ -z "$FIREBASE_SERVICE_ACCOUNT" ]; then
             echo "::error::The FIREBASE_SERVICE_ACCOUNT secret is missing. Deployment cannot proceed."
@@ -38,7 +38,7 @@ jobs:
         id: auth
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"
+          credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
 
       - name: Run deploy preflight
         run: npm run deploy:preflight

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules
 .firebase
 *.log
 android/.idea
+playwright-report/
+test-results/
+worktrees/

--- a/DESIGN_OVERVIEW.md
+++ b/DESIGN_OVERVIEW.md
@@ -1,9 +1,11 @@
 # Todo App Design Overview
 
 ## Architecture
+
 The application is a real-time collaborative Todo list built with SvelteKit and Firebase.
 
 ### Frontend
+
 - **Framework**: SvelteKit
 - **State Management**: A custom Redux-like store implemented using Svelte stores (`src/lib/store.ts`). It handles actions, state transitions, and real-time synchronization.
 - **UI Components**: Svelte Material UI (SMUI) for a consistent Material Design look and feel.
@@ -11,14 +13,17 @@ The application is a real-time collaborative Todo list built with SvelteKit and 
 - **Offline Support**: IndexedDB is used to cache state locally, allowing for fast initial loads and offline availability.
 
 ### Backend
+
 - **Database**: Firebase Firestore. Data is organized into `lists`, `actions`, and `users`.
 - **Cloud Functions**: Used for background tasks like sending notifications and updating activity logs based on Firestore triggers.
 - **Authentication**: Firebase Auth for user management.
 
 ### Mobile
+
 - **Capacitor**: Used to package the web application as a native mobile app for Android and iOS.
 
 ## Testing
+
 - **Unit/Integration**: Vitest for testing business logic and store transitions.
 - **E2E**: Playwright for end-to-end testing, utilizing the Firebase Emulator for a consistent and isolated test environment.
   - **Zero-Pixel Tolerance**: Every atomic test step captures a visual snapshot to verify UI state.

--- a/docs/FIREBASE_ADMIN_SETUP.md
+++ b/docs/FIREBASE_ADMIN_SETUP.md
@@ -24,7 +24,7 @@ In the **Grant this service account access to project** section, add the followi
 - **Cloud Build Editor**: Required for the build step of Cloud Functions.
 - **Artifact Registry Administrator**: Required to store the function images.
 
-*Note: If you have a highly complex setup, you might need additional roles like "API Gateway Admin" or "Secret Manager Secret Accessor", but the above are the standard requirements for a full Firebase CLI deployment.*
+_Note: If you have a highly complex setup, you might need additional roles like "API Gateway Admin" or "Secret Manager Secret Accessor", but the above are the standard requirements for a full Firebase CLI deployment._
 
 Click **CONTINUE** and then **DONE**.
 

--- a/docs/PR_PREVIEWS_DESIGN.md
+++ b/docs/PR_PREVIEWS_DESIGN.md
@@ -1,13 +1,16 @@
 # PR Previews Design
 
 ## Objective
+
 Provide a way to test Pull Request (PR) changes in a production-like environment before merging them into the main branch. This allows for manual verification and stakeholder review on a live URL.
 
 ## Technology Selection
+
 - **GitHub Actions**: For automating the build and deployment process.
 - **Firebase Hosting Preview Channels**: To host temporary versions of the site for each PR.
 
 ## Workflow Details
+
 1. **Trigger**: The workflow will trigger on `pull_request` events, specifically when a PR is `opened`, `synchronized`, or `reopened`.
 2. **Build Process**:
    - Install dependencies: `npm ci`
@@ -19,7 +22,9 @@ Provide a way to test Pull Request (PR) changes in a production-like environment
    - The action will automatically comment on the PR with the preview URL once the deployment is successful.
 
 ## Security and Secrets
+
 - A `FIREBASE_SERVICE_ACCOUNT` secret must be added to the GitHub repository. This service account should have the necessary permissions to deploy to Firebase Hosting.
 
 ## Cleanup
+
 - Firebase Hosting automatically handles the cleanup of preview channels. When a PR is closed, the associated preview channel and its temporary URL are eventually deleted, ensuring no orphaned resources remain.

--- a/flake.lock
+++ b/flake.lock
@@ -1,27 +1,27 @@
 {
-  "nodes": {
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      }
-    }
-  },
-  "root": "root",
-  "version": 7
+	"nodes": {
+		"nixpkgs": {
+			"locked": {
+				"lastModified": 1778869304,
+				"narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+				"owner": "NixOS",
+				"repo": "nixpkgs",
+				"rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+				"type": "github"
+			},
+			"original": {
+				"owner": "NixOS",
+				"ref": "nixpkgs-unstable",
+				"repo": "nixpkgs",
+				"type": "github"
+			}
+		},
+		"root": {
+			"inputs": {
+				"nixpkgs": "nixpkgs"
+			}
+		}
+	},
+	"root": "root",
+	"version": 7
 }

--- a/flake.nix
+++ b/flake.nix
@@ -29,11 +29,12 @@
               coreutils
               git
               google-cloud-sdk
+              jdk17
               nodejs_22
             ];
 
             shellHook = ''
-              echo "todo dev shell: run npm ci, then npm run deploy:preflight -- path/to/service-account.json"
+              echo "todo dev shell: run npm ci, npm run deploy:preflight -- path/to/service-account.json, or npm run playwright"
             '';
           };
         }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,7 @@ const config: PlaywrightTestConfig = {
 	],
 	testDir: 'tests/e2e',
 	timeout: 60000,
+	workers: process.env.CI ? 1 : undefined,
 	use: {
 		baseURL: 'http://127.0.0.1:4173',
 		trace: 'on-first-retry'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,8 @@ const config: PlaywrightTestConfig = {
 			timeout: 120000
 		},
 		{
-			command: 'npx firebase emulators:start --only firestore,auth --project todo-firebase-1a740 --non-interactive',
+			command:
+				'npx firebase emulators:start --only firestore,auth --project todo-firebase-1a740 --non-interactive',
 			url: 'http://127.0.0.1:9099',
 			reuseExistingServer: true,
 			timeout: 120000

--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -270,7 +270,6 @@
 		onPointerDown: (e: PointerEvent) => {
 			if (dragEnabled) {
 				pointerX = e.clientX;
-				(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
 				target = document.elementFromPoint(e.clientX, e.clientY)?.closest('.item');
 				if (target) {
 					window.setTimeout(() => {

--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -7,7 +7,7 @@
 	import { flip } from 'svelte/animate';
 	import ItemDisplay from './ItemDisplay.svelte';
 	import { Capacitor } from '@capacitor/core';
-	import { createDragAutoScroller } from './autoscroll';
+	import { createDragAutoScroller, findDragTarget } from './autoscroll';
 
 	export let listIdMatcher: (listId: string) => boolean = () => true;
 	export let filter: (listId: string, itemId: string) => boolean = () => true;
@@ -172,32 +172,16 @@
 	}
 
 	function updateDragTarget(clientX: number, clientY: number, edgeDirection: -1 | 0 | 1 = 0) {
-		const midPoint = clientY + offsetY + boxHeight / 2;
-		let target: HTMLElement | null | undefined = document
-			.elementFromPoint(clientX, midPoint)
-			?.closest('.item');
-		const candidates = Array.from(
-			container?.querySelectorAll<HTMLElement>('.item:not(#ghost):not(#grabbed)') || []
-		);
-		const grabbedIndex = Number(grabbed?.dataset.index ?? -1);
-		if (edgeDirection < 0 && candidates.length && grabbedIndex > 0) {
-			target = candidates[0];
-		} else if (edgeDirection > 0 && candidates.length && grabbedIndex < items.length - 1) {
-			target = candidates[candidates.length - 1];
-		}
-		if (!target || target === grabbed || target.id === 'ghost' || !container?.contains(target)) {
-			const rect = container?.getBoundingClientRect();
-			if (rect && candidates.length && midPoint < rect.top && grabbedIndex > 0) {
-				target = candidates[0];
-			} else if (
-				rect &&
-				candidates.length &&
-				midPoint > rect.bottom &&
-				grabbedIndex < items.length - 1
-			) {
-				target = candidates[candidates.length - 1];
-			}
-		}
+		const target = findDragTarget({
+			clientX,
+			clientY,
+			offsetY,
+			boxHeight,
+			edgeDirection,
+			container,
+			grabbed,
+			itemCount: items.length
+		});
 		if (target && (target != lastTarget || edgeDirection !== 0)) {
 			lastTarget = target;
 			dragEnter(target);

--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -269,17 +269,20 @@
 	let containerDragHandlers = {
 		onPointerDown: (e: PointerEvent) => {
 			if (dragEnabled) {
+				const pointerId = e.pointerId;
+				const clientY = e.clientY;
+				const currentTarget = e.currentTarget as HTMLElement;
 				pointerX = e.clientX;
-				target = document.elementFromPoint(e.clientX, e.clientY)?.closest('.item');
+				target = document.elementFromPoint(e.clientX, e.clientY)?.closest('.item') as HTMLElement;
 				if (target) {
 					window.setTimeout(() => {
 						if (target) {
-							// console.log('onPointerDown GRAB');
-							grab(e.clientY, target);
+							currentTarget.setPointerCapture(pointerId);
+							grab(clientY, target);
 						} else {
 							// console.log('onPointerDown no grab');
 						}
-					}, 50 + touchTimeout);
+					}, 100 + touchTimeout);
 				}
 			}
 		},

--- a/src/lib/components/ItemList.svelte
+++ b/src/lib/components/ItemList.svelte
@@ -7,6 +7,7 @@
 	import { flip } from 'svelte/animate';
 	import ItemDisplay from './ItemDisplay.svelte';
 	import { Capacitor } from '@capacitor/core';
+	import { createDragAutoScroller } from './autoscroll';
 
 	export let listIdMatcher: (listId: string) => boolean = () => true;
 	export let filter: (listId: string, itemId: string) => boolean = () => true;
@@ -136,6 +137,7 @@
 		if (grabbed) {
 			mouseY = clientY;
 			layerY = anchor.getBoundingClientRect().y;
+			autoScroller.update(clientY);
 			// console.log( 'mouseY ' + mouseY + ' offsetY ' + offsetY + ' -layerY ' + layerY + ' = ' + (mouseY + offsetY - layerY));
 		} else {
 			console.log('drag: grabbed is not set');
@@ -169,6 +171,39 @@
 		}
 	}
 
+	function updateDragTarget(clientX: number, clientY: number, edgeDirection: -1 | 0 | 1 = 0) {
+		const midPoint = clientY + offsetY + boxHeight / 2;
+		let target: HTMLElement | null | undefined = document
+			.elementFromPoint(clientX, midPoint)
+			?.closest('.item');
+		const candidates = Array.from(
+			container?.querySelectorAll<HTMLElement>('.item:not(#ghost):not(#grabbed)') || []
+		);
+		const grabbedIndex = Number(grabbed?.dataset.index ?? -1);
+		if (edgeDirection < 0 && candidates.length && grabbedIndex > 0) {
+			target = candidates[0];
+		} else if (edgeDirection > 0 && candidates.length && grabbedIndex < items.length - 1) {
+			target = candidates[candidates.length - 1];
+		}
+		if (!target || target === grabbed || target.id === 'ghost' || !container?.contains(target)) {
+			const rect = container?.getBoundingClientRect();
+			if (rect && candidates.length && midPoint < rect.top && grabbedIndex > 0) {
+				target = candidates[0];
+			} else if (
+				rect &&
+				candidates.length &&
+				midPoint > rect.bottom &&
+				grabbedIndex < items.length - 1
+			) {
+				target = candidates[candidates.length - 1];
+			}
+		}
+		if (target && (target != lastTarget || edgeDirection !== 0)) {
+			lastTarget = target;
+			dragEnter(target);
+		}
+	}
+
 	// does the actual moving of items in data
 	function moveDatum(from: number, to: number) {
 		let temp = items[from];
@@ -182,6 +217,7 @@
 	}
 
 	function release() {
+		autoScroller.stop();
 		if (!dragTimeElapsed) {
 			console.log('ignore drag');
 			window.setTimeout(() => (dragTimeElapsed = false), 400);
@@ -222,11 +258,19 @@
 	}
 
 	let target: HTMLElement | null | undefined = null;
+	let pointerX = 0;
 	let touchTimeout = Capacitor.isNativePlatform() ? 400 : 0;
+	let autoScroller = createDragAutoScroller(() => container, (direction, didScroll) => {
+		if (grabbed) {
+			updateDragTarget(pointerX, mouseY, didScroll ? 0 : direction);
+		}
+	});
 
 	let containerDragHandlers = {
 		onPointerDown: (e: PointerEvent) => {
 			if (dragEnabled) {
+				pointerX = e.clientX;
+				(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
 				target = document.elementFromPoint(e.clientX, e.clientY)?.closest('.item');
 				if (target) {
 					window.setTimeout(() => {
@@ -246,23 +290,18 @@
 				e.preventDefault();
 
 				if (grabbed) {
+					pointerX = e.clientX;
 					drag(e.clientY);
-					const midPoint = e.clientY + offsetY + boxHeight / 2;
-					let target: HTMLElement | null | undefined = document
-						.elementFromPoint(e.clientX, midPoint)
-						?.closest('.item');
-					if (target) {
-						if (target != lastTarget) {
-							lastTarget = target;
-							dragEnter(target);
-						}
-					}
+					updateDragTarget(e.clientX, e.clientY);
 				}
 			}
 		},
 		onPointerUp: (e: PointerEvent) => {
 			if (dragEnabled) {
 				release();
+			}
+			if ((e.currentTarget as HTMLElement).hasPointerCapture(e.pointerId)) {
+				(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
 			}
 			target = null;
 		},
@@ -271,23 +310,14 @@
 		},
 		onTouchMove: (e: TouchEvent) => {
 			if (dragEnabled && grabbed) {
-				e.preventDefault();
-				const x = e.touches[0].clientX;
-				const y = e.touches[0].clientY;
-				drag(y);
-
-				const midPoint = y + offsetY + boxHeight / 2;
-				let target: HTMLElement | null | undefined = document
-					.elementFromPoint(x, midPoint)
-					?.closest('.item');
-				if (target) {
-					if (target != lastTarget) {
-						lastTarget = target;
-						dragEnter(target);
-					}
+					e.preventDefault();
+					const x = e.touches[0].clientX;
+					const y = e.touches[0].clientY;
+					pointerX = x;
+					drag(y);
+					updateDragTarget(x, y);
 				}
-			}
-		},
+			},
 		onTouchEnd: (e: TouchEvent) => {
 			if (dragEnabled) {
 				release();
@@ -295,6 +325,9 @@
 			target = null;
 		},
 		onPointerCancel: (e: PointerEvent) => {
+			if ((e.currentTarget as HTMLElement).hasPointerCapture(e.pointerId)) {
+				(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+			}
 			target = null;
 		}
 	};

--- a/src/lib/components/ListMenu.svelte
+++ b/src/lib/components/ListMenu.svelte
@@ -225,8 +225,6 @@
 			target = null;
 		},
 		onPointerCancel: (e: PointerEvent) => {
-			autoScroller.stop();
-			grabbed = null;
 			if ((e.currentTarget as HTMLElement).hasPointerCapture(e.pointerId)) {
 				(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
 			}

--- a/src/lib/components/ListMenu.svelte
+++ b/src/lib/components/ListMenu.svelte
@@ -7,7 +7,7 @@
 	import ListMenuItem from './ListMenuItem.svelte';
 	import { reorder_list } from './lists';
 	import { Capacitor } from '@capacitor/core';
-	import { createDragAutoScroller } from './autoscroll';
+	import { createDragAutoScroller, findDragTarget } from './autoscroll';
 
 	/*
 	export let send: (
@@ -102,32 +102,16 @@
 	}
 
 	function updateDragTarget(clientX: number, clientY: number, edgeDirection: -1 | 0 | 1 = 0) {
-		const midPoint = clientY + offsetY + boxHeight / 2;
-		let target: HTMLElement | null | undefined = document
-			.elementFromPoint(clientX, midPoint)
-			?.closest('.item');
-		const candidates = Array.from(
-			container?.querySelectorAll<HTMLElement>('.item:not(#ghost):not(#grabbed)') || []
-		);
-		const grabbedIndex = Number(grabbed?.dataset.index ?? -1);
-		if (edgeDirection < 0 && candidates.length && grabbedIndex > 0) {
-			target = candidates[0];
-		} else if (edgeDirection > 0 && candidates.length && grabbedIndex < items.length - 1) {
-			target = candidates[candidates.length - 1];
-		}
-		if (!target || target === grabbed || target.id === 'ghost' || !container?.contains(target)) {
-			const rect = container?.getBoundingClientRect();
-			if (rect && candidates.length && midPoint < rect.top && grabbedIndex > 0) {
-				target = candidates[0];
-			} else if (
-				rect &&
-				candidates.length &&
-				midPoint > rect.bottom &&
-				grabbedIndex < items.length - 1
-			) {
-				target = candidates[candidates.length - 1];
-			}
-		}
+		const target = findDragTarget({
+			clientX,
+			clientY,
+			offsetY,
+			boxHeight,
+			edgeDirection,
+			container,
+			grabbed,
+			itemCount: items.length
+		});
 		if (target && (target != lastTarget || edgeDirection !== 0)) {
 			lastTarget = target;
 			dragEnter(target);

--- a/src/lib/components/ListMenu.svelte
+++ b/src/lib/components/ListMenu.svelte
@@ -177,24 +177,25 @@
 
 	let containerDragHandlers = {
 		onPointerDown: (e: PointerEvent) => {
+			const pointerId = e.pointerId;
+			const clientY = e.clientY;
+			const currentTarget = e.currentTarget as HTMLElement;
 			pointerX = e.clientX;
-			(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-			target = document.elementFromPoint(e.clientX, e.clientY)?.closest('.item');
+			target = document.elementFromPoint(e.clientX, e.clientY)?.closest('.item') as HTMLElement;
 			if (target) {
 				window.setTimeout(() => {
 					if (target) {
-						// console.log('onPointerDown GRAB');
-						grab(e.clientY, target);
+						currentTarget.setPointerCapture(pointerId);
+						grab(clientY, target);
 					} else {
 						// console.log('onPointerDown no grab');
 					}
-				}, 50 + touchTimeout);
+				}, 100 + touchTimeout);
 			}
 		},
 		onPointerMove: (e: PointerEvent) => {
-			e.stopPropagation();
-			e.preventDefault();
 			if (grabbed) {
+				e.preventDefault();
 				pointerX = e.clientX;
 				drag(e.clientY);
 				updateDragTarget(e.clientX, e.clientY);

--- a/src/lib/components/ListMenu.svelte
+++ b/src/lib/components/ListMenu.svelte
@@ -7,6 +7,7 @@
 	import ListMenuItem from './ListMenuItem.svelte';
 	import { reorder_list } from './lists';
 	import { Capacitor } from '@capacitor/core';
+	import { createDragAutoScroller } from './autoscroll';
 
 	/*
 	export let send: (
@@ -69,6 +70,7 @@
 		if (grabbed) {
 			mouseY = clientY;
 			layerY = anchor.getBoundingClientRect().y;
+			autoScroller.update(clientY);
 		}
 	}
 
@@ -99,6 +101,39 @@
 		}
 	}
 
+	function updateDragTarget(clientX: number, clientY: number, edgeDirection: -1 | 0 | 1 = 0) {
+		const midPoint = clientY + offsetY + boxHeight / 2;
+		let target: HTMLElement | null | undefined = document
+			.elementFromPoint(clientX, midPoint)
+			?.closest('.item');
+		const candidates = Array.from(
+			container?.querySelectorAll<HTMLElement>('.item:not(#ghost):not(#grabbed)') || []
+		);
+		const grabbedIndex = Number(grabbed?.dataset.index ?? -1);
+		if (edgeDirection < 0 && candidates.length && grabbedIndex > 0) {
+			target = candidates[0];
+		} else if (edgeDirection > 0 && candidates.length && grabbedIndex < items.length - 1) {
+			target = candidates[candidates.length - 1];
+		}
+		if (!target || target === grabbed || target.id === 'ghost' || !container?.contains(target)) {
+			const rect = container?.getBoundingClientRect();
+			if (rect && candidates.length && midPoint < rect.top && grabbedIndex > 0) {
+				target = candidates[0];
+			} else if (
+				rect &&
+				candidates.length &&
+				midPoint > rect.bottom &&
+				grabbedIndex < items.length - 1
+			) {
+				target = candidates[candidates.length - 1];
+			}
+		}
+		if (target && (target != lastTarget || edgeDirection !== 0)) {
+			lastTarget = target;
+			dragEnter(target);
+		}
+	}
+
 	// does the actual moving of items in data
 	function moveDatum(from: number, to: number) {
 		let temp = items[from];
@@ -112,6 +147,7 @@
 	}
 
 	function release() {
+		autoScroller.stop();
 		if (
 			$store.auth.uid &&
 			grabbed &&
@@ -130,10 +166,19 @@
 	}
 
 	let target: HTMLElement | null | undefined = null;
+	let pointerX = 0;
 	let touchTimeout = Capacitor.isNativePlatform() ? 400 : 0;
+	let container: Element | undefined = undefined;
+	let autoScroller = createDragAutoScroller(() => container, (direction, didScroll) => {
+		if (grabbed) {
+			updateDragTarget(pointerX, mouseY, didScroll ? 0 : direction);
+		}
+	});
 
 	let containerDragHandlers = {
 		onPointerDown: (e: PointerEvent) => {
+			pointerX = e.clientX;
+			(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
 			target = document.elementFromPoint(e.clientX, e.clientY)?.closest('.item');
 			if (target) {
 				window.setTimeout(() => {
@@ -150,21 +195,16 @@
 			e.stopPropagation();
 			e.preventDefault();
 			if (grabbed) {
+				pointerX = e.clientX;
 				drag(e.clientY);
-				const midPoint = e.clientY + offsetY + boxHeight / 2;
-				let target: HTMLElement | null | undefined = document
-					.elementFromPoint(e.clientX, midPoint)
-					?.closest('.item');
-				if (target) {
-					if (target != lastTarget) {
-						lastTarget = target;
-						dragEnter(target);
-					}
-				}
+				updateDragTarget(e.clientX, e.clientY);
 			}
 		},
 		onPointerUp: (e: PointerEvent) => {
 			release();
+			if ((e.currentTarget as HTMLElement).hasPointerCapture(e.pointerId)) {
+				(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+			}
 			target = null;
 		},
 		onTouchStart: (e: TouchEvent) => {
@@ -175,18 +215,9 @@
 				e.preventDefault();
 				const x = e.touches[0].clientX;
 				const y = e.touches[0].clientY;
+				pointerX = x;
 				drag(y);
-
-				const midPoint = y + offsetY + boxHeight / 2;
-				let target: HTMLElement | null | undefined = document
-					.elementFromPoint(x, midPoint)
-					?.closest('.item');
-				if (target) {
-					if (target != lastTarget) {
-						lastTarget = target;
-						dragEnter(target);
-					}
-				}
+				updateDragTarget(x, y);
 			}
 		},
 		onTouchEnd: (e: TouchEvent) => {
@@ -194,6 +225,11 @@
 			target = null;
 		},
 		onPointerCancel: (e: PointerEvent) => {
+			autoScroller.stop();
+			grabbed = null;
+			if ((e.currentTarget as HTMLElement).hasPointerCapture(e.pointerId)) {
+				(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+			}
 			target = null;
 		}
 	};
@@ -203,6 +239,7 @@
 
 <div
 	class="listContainer"
+	bind:this={container}
 	on:pointerdown={containerDragHandlers.onPointerDown}
 	on:pointermove={containerDragHandlers.onPointerMove}
 	on:pointerup={containerDragHandlers.onPointerUp}

--- a/src/lib/components/autoscroll.ts
+++ b/src/lib/components/autoscroll.ts
@@ -1,6 +1,17 @@
 const EDGE_SIZE_PX = 96;
 const MAX_SCROLL_PX_PER_FRAME = 24;
 
+type DragTargetOptions = {
+	clientX: number;
+	clientY: number;
+	offsetY: number;
+	boxHeight: number;
+	edgeDirection?: -1 | 0 | 1;
+	container: Element | null | undefined;
+	grabbed: HTMLElement | null | undefined;
+	itemCount: number;
+};
+
 function isScrollable(element: HTMLElement) {
 	const style = getComputedStyle(element);
 	const overflowY = style.overflowY;
@@ -21,6 +32,45 @@ function findScrollContainer(element: Element | null | undefined) {
 function scrollSpeed(distanceIntoEdge: number) {
 	const ratio = Math.min(Math.max(distanceIntoEdge / EDGE_SIZE_PX, 0), 1);
 	return Math.ceil(ratio * MAX_SCROLL_PX_PER_FRAME);
+}
+
+export function findDragTarget({
+	clientX,
+	clientY,
+	offsetY,
+	boxHeight,
+	edgeDirection = 0,
+	container,
+	grabbed,
+	itemCount
+}: DragTargetOptions) {
+	const midPoint = clientY + offsetY + boxHeight / 2;
+	let target: HTMLElement | null | undefined = document
+		.elementFromPoint(clientX, midPoint)
+		?.closest('.item');
+	const candidates = Array.from(
+		container?.querySelectorAll<HTMLElement>('.item:not(#ghost):not(#grabbed)') || []
+	);
+	const grabbedIndex = Number(grabbed?.dataset.index ?? -1);
+	if (edgeDirection < 0 && candidates.length && grabbedIndex > 0) {
+		target = candidates[0];
+	} else if (edgeDirection > 0 && candidates.length && grabbedIndex < itemCount - 1) {
+		target = candidates[candidates.length - 1];
+	}
+	if (!target || target === grabbed || target.id === 'ghost' || !container?.contains(target)) {
+		const rect = container?.getBoundingClientRect();
+		if (rect && candidates.length && midPoint < rect.top && grabbedIndex > 0) {
+			target = candidates[0];
+		} else if (
+			rect &&
+			candidates.length &&
+			midPoint > rect.bottom &&
+			grabbedIndex < itemCount - 1
+		) {
+			target = candidates[candidates.length - 1];
+		}
+	}
+	return target;
 }
 
 export function createDragAutoScroller(

--- a/src/lib/components/autoscroll.ts
+++ b/src/lib/components/autoscroll.ts
@@ -1,0 +1,83 @@
+const EDGE_SIZE_PX = 96;
+const MAX_SCROLL_PX_PER_FRAME = 24;
+
+function isScrollable(element: HTMLElement) {
+	const style = getComputedStyle(element);
+	const overflowY = style.overflowY;
+	return (
+		(overflowY === 'auto' || overflowY === 'scroll') && element.scrollHeight > element.clientHeight
+	);
+}
+
+function findScrollContainer(element: Element | null | undefined) {
+	let current = element?.parentElement;
+	while (current) {
+		if (isScrollable(current)) {
+			return current;
+		}
+		current = current.parentElement;
+	}
+	return document.scrollingElement instanceof HTMLElement ? document.scrollingElement : null;
+}
+
+function scrollSpeed(distanceIntoEdge: number) {
+	const ratio = Math.min(Math.max(distanceIntoEdge / EDGE_SIZE_PX, 0), 1);
+	return Math.ceil(ratio * MAX_SCROLL_PX_PER_FRAME);
+}
+
+export function createDragAutoScroller(
+	getElement: () => Element | null | undefined,
+	onScroll?: (direction: -1 | 1, didScroll: boolean) => void
+) {
+	let pointerY = 0;
+	let animationFrame = 0;
+	let scrollContainer: HTMLElement | null = null;
+
+	function stop() {
+		if (animationFrame) {
+			cancelAnimationFrame(animationFrame);
+			animationFrame = 0;
+		}
+		scrollContainer = null;
+	}
+
+	function tick() {
+		animationFrame = 0;
+		if (!scrollContainer) {
+			return;
+		}
+
+		const rect = scrollContainer.getBoundingClientRect();
+		let delta = 0;
+		if (pointerY < rect.top + EDGE_SIZE_PX) {
+			delta = -scrollSpeed(rect.top + EDGE_SIZE_PX - pointerY);
+		} else if (pointerY > rect.bottom - EDGE_SIZE_PX) {
+			delta = scrollSpeed(pointerY - (rect.bottom - EDGE_SIZE_PX));
+		}
+
+		if (delta === 0) {
+			return;
+		}
+
+		const previousScrollTop = scrollContainer.scrollTop;
+		scrollContainer.scrollTop += delta;
+		const didScroll = scrollContainer.scrollTop !== previousScrollTop;
+		onScroll?.(delta < 0 ? -1 : 1, didScroll);
+		if (didScroll) {
+			animationFrame = requestAnimationFrame(tick);
+		}
+	}
+
+	function update(clientY: number) {
+		pointerY = clientY;
+		scrollContainer = scrollContainer || findScrollContainer(getElement());
+		if (scrollContainer && !animationFrame) {
+			animationFrame = requestAnimationFrame(tick);
+		}
+	}
+
+	return {
+		stop,
+		update
+	};
+}

--- a/src/lib/components/autoscroll.ts
+++ b/src/lib/components/autoscroll.ts
@@ -4,9 +4,7 @@ const MAX_SCROLL_PX_PER_FRAME = 24;
 function isScrollable(element: HTMLElement) {
 	const style = getComputedStyle(element);
 	const overflowY = style.overflowY;
-	return (
-		(overflowY === 'auto' || overflowY === 'scroll') && element.scrollHeight > element.clientHeight
-	);
+	return overflowY === 'auto' || overflowY === 'scroll';
 }
 
 function findScrollContainer(element: Element | null | undefined) {

--- a/tests/e2e/001-login/001-login.spec.ts
+++ b/tests/e2e/001-login/001-login.spec.ts
@@ -4,7 +4,9 @@ import { TestStepHelper } from '../helpers/test-step-helper';
 test.beforeEach(async ({ request }) => {
 	// Ensure that the E2E tests start with a clean state in the emulator.
 	const projectId = 'todo-firebase-1a740';
-	await request.delete(`http://127.0.0.1:8080/emulator/v1/projects/${projectId}/databases/(default)/documents`);
+	await request.delete(
+		`http://127.0.0.1:8080/emulator/v1/projects/${projectId}/databases/(default)/documents`
+	);
 });
 
 test('login page verification', async ({ page }, testInfo) => {
@@ -14,7 +16,8 @@ test('login page verification', async ({ page }, testInfo) => {
 	await page.goto('/');
 
 	await helper.step('login_page', {
-		description: 'User navigates to the home page and is redirected to the login page, where content and button are verified.',
+		description:
+			'User navigates to the home page and is redirected to the login page, where content and button are verified.',
 		verifications: [
 			{
 				spec: 'URL is /login',
@@ -39,7 +42,9 @@ test('login page verification', async ({ page }, testInfo) => {
 			{
 				spec: 'Welcome message is present',
 				check: async () => {
-					const welcomeMessage = page.locator('p').filter({ hasText: 'Welcome to Todo. Please sign in.' });
+					const welcomeMessage = page
+						.locator('p')
+						.filter({ hasText: 'Welcome to Todo. Please sign in.' });
 					await expect(welcomeMessage).toBeVisible();
 				}
 			},

--- a/tests/e2e/001-login/README.md
+++ b/tests/e2e/001-login/README.md
@@ -9,6 +9,7 @@ Verify the initial state of the login page.
 User navigates to the home page and is redirected to the login page, where content and button are verified.
 
 **Verifications:**
+
 - [x] URL is /login
 - [x] Title is Todo
 - [x] Heading contains TODOs
@@ -16,4 +17,3 @@ User navigates to the home page and is redirected to the login page, where conte
 - [x] Login button is visible
 
 ![login_page](screenshots/001-login-page.png)
-

--- a/tests/e2e/002-auth-flow/002-auth-flow.spec.ts
+++ b/tests/e2e/002-auth-flow/002-auth-flow.spec.ts
@@ -4,9 +4,11 @@ import { TestStepHelper } from '../helpers/test-step-helper';
 test.beforeEach(async ({ request }) => {
 	// Ensure that the E2E tests start with a clean state in the emulator.
 	const projectId = 'todo-firebase-1a740';
-	await request.delete(`http://127.0.0.1:8080/emulator/v1/projects/${projectId}/databases/(default)/documents`);
-	
-	// Optional: Clear Auth users if possible. 
+	await request.delete(
+		`http://127.0.0.1:8080/emulator/v1/projects/${projectId}/databases/(default)/documents`
+	);
+
+	// Optional: Clear Auth users if possible.
 	// The Firebase Auth emulator has a REST API for this:
 	// DELETE http://127.0.0.1:9099/emulator/v1/projects/{project-id}/accounts
 	await request.delete(`http://127.0.0.1:9099/emulator/v1/projects/${projectId}/accounts`);
@@ -14,23 +16,34 @@ test.beforeEach(async ({ request }) => {
 
 test('successful login and profile view', async ({ page }, testInfo) => {
 	const helper = new TestStepHelper(page, testInfo);
-	helper.setMetadata('Successful Login Flow', 'Verify that a user can sign in using the Sign In button and view their profile.');
+	helper.setMetadata(
+		'Successful Login Flow',
+		'Verify that a user can sign in using the Sign In button and view their profile.'
+	);
 
 	await page.goto('/');
 
 	await helper.step('login_page', {
 		description: 'User is on the login page.',
 		verifications: [
-			{ spec: 'Login button is visible', check: async () => expect(page.getByRole('button', { name: 'Sign In', exact: true })).toBeVisible() }
+			{
+				spec: 'Login button is visible',
+				check: async () =>
+					expect(page.getByRole('button', { name: 'Sign In', exact: true })).toBeVisible()
+			}
 		]
 	});
 
 	await page.getByRole('button', { name: 'Sign In', exact: true }).click();
 
 	await helper.step('after_login', {
-		description: 'User clicked test sign in and should be redirected to profile page (via home page).',
+		description:
+			'User clicked test sign in and should be redirected to profile page (via home page).',
 		verifications: [
-			{ spec: 'Redirected to profile page', check: async () => expect(page).toHaveURL(/\/profile/, { timeout: 10000 }) }
+			{
+				spec: 'Redirected to profile page',
+				check: async () => expect(page).toHaveURL(/\/profile/, { timeout: 10000 })
+			}
 		]
 	});
 
@@ -41,16 +54,22 @@ test('successful login and profile view', async ({ page }, testInfo) => {
 		description: 'User is on the profile page.',
 		verifications: [
 			{ spec: 'URL is /profile', check: async () => expect(page).toHaveURL(/\/profile/) },
-			{ spec: 'Email is visible', check: async () => expect(page.locator('p', { hasText: 'test@example.com' })).toBeVisible() },
-			{ spec: 'Name is visible', check: async () => expect(page.locator('p', { hasText: 'Test User' })).toBeVisible() }
+			{
+				spec: 'Email is visible',
+				check: async () => expect(page.locator('p', { hasText: 'test@example.com' })).toBeVisible()
+			},
+			{
+				spec: 'Name is visible',
+				check: async () => expect(page.locator('p', { hasText: 'Test User' })).toBeVisible()
+			}
 		]
 	});
 
 	await helper.step('create_list_step', {
 		description: 'User creates a new todo list.',
 		verifications: [
-			{ 
-				spec: 'New list input is visible', 
+			{
+				spec: 'New list input is visible',
 				check: async () => {
 					const newListInput = page.getByLabel('New list');
 					if (!(await newListInput.isVisible())) {
@@ -60,7 +79,7 @@ test('successful login and profile view', async ({ page }, testInfo) => {
 						}
 					}
 					await expect(newListInput).toBeVisible();
-				} 
+				}
 			}
 		]
 	});
@@ -71,7 +90,10 @@ test('successful login and profile view', async ({ page }, testInfo) => {
 	await helper.step('entering_list_name', {
 		description: 'User has entered the new list name but has not yet submitted.',
 		verifications: [
-			{ spec: 'Input contains the list name', check: async () => expect(page.getByLabel('New list')).toHaveValue(listName) }
+			{
+				spec: 'Input contains the list name',
+				check: async () => expect(page.getByLabel('New list')).toHaveValue(listName)
+			}
 		]
 	});
 
@@ -80,8 +102,17 @@ test('successful login and profile view', async ({ page }, testInfo) => {
 	await helper.step('list_created', {
 		description: 'User created a new list and is redirected to it.',
 		verifications: [
-			{ spec: 'URL contains the new list ID', check: async () => expect(page).toHaveURL(/lists\?listId=/) },
-			{ spec: 'List title matches', check: async () => expect(page.locator('.mdc-top-app-bar__title').filter({ hasText: listName })).toBeVisible() }
+			{
+				spec: 'URL contains the new list ID',
+				check: async () => expect(page).toHaveURL(/lists\?listId=/)
+			},
+			{
+				spec: 'List title matches',
+				check: async () =>
+					expect(
+						page.locator('.mdc-top-app-bar__title').filter({ hasText: listName })
+					).toBeVisible()
+			}
 		]
 	});
 

--- a/tests/e2e/002-auth-flow/README.md
+++ b/tests/e2e/002-auth-flow/README.md
@@ -9,6 +9,7 @@ Verify that a user can sign in using the Sign In button and view their profile.
 User is on the login page.
 
 **Verifications:**
+
 - [x] Login button is visible
 
 ![login_page](screenshots/001-login-page.png)
@@ -18,6 +19,7 @@ User is on the login page.
 User clicked test sign in and should be redirected to profile page (via home page).
 
 **Verifications:**
+
 - [x] Redirected to profile page
 
 ![after_login](screenshots/002-after-login.png)
@@ -27,6 +29,7 @@ User clicked test sign in and should be redirected to profile page (via home pag
 User is on the profile page.
 
 **Verifications:**
+
 - [x] URL is /profile
 - [x] Email is visible
 - [x] Name is visible
@@ -38,6 +41,7 @@ User is on the profile page.
 User creates a new todo list.
 
 **Verifications:**
+
 - [x] New list input is visible
 
 ![create_list_step](screenshots/004-create-list-step.png)
@@ -47,6 +51,7 @@ User creates a new todo list.
 User has entered the new list name but has not yet submitted.
 
 **Verifications:**
+
 - [x] Input contains the list name
 
 ![entering_list_name](screenshots/005-entering-list-name.png)
@@ -56,6 +61,7 @@ User has entered the new list name but has not yet submitted.
 User created a new list and is redirected to it.
 
 **Verifications:**
+
 - [x] URL contains the new list ID
 - [x] List title matches
 
@@ -66,7 +72,7 @@ User created a new list and is redirected to it.
 User clicked sign out and should be redirected to login page.
 
 **Verifications:**
+
 - [x] Redirected to login page
 
 ![after_signout](screenshots/007-after-signout.png)
-

--- a/tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts
+++ b/tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts
@@ -27,11 +27,11 @@ async function createList(page: Page, listName: string) {
 async function createTodoItems(page: Page, itemNames: string[]) {
 	const newTask = page.getByLabel('New task');
 	await expect(newTask).toBeVisible();
-	await page.waitForTimeout(800);
+	await page.waitForTimeout(1500);
 	for (const [index, itemName] of [...itemNames].reverse().entries()) {
 		await newTask.fill(itemName);
 		await page.keyboard.press('Enter');
-		await expect(todoInputs(page)).toHaveCount(index + 1, { timeout: 10000 });
+		await expect(todoInputs(page)).toHaveCount(index + 1, { timeout: 15000 });
 	}
 }
 
@@ -69,12 +69,12 @@ async function dragVisibleRowTowardTopOfViewport(
 
 	await page.mouse.move(startX, startY);
 	await page.mouse.down();
-	await page.waitForTimeout(150);
+	await page.waitForTimeout(500);
 	await page.mouse.move(startX, topDragY, { steps: 20 });
-	await page.waitForTimeout(1600);
+	await page.waitForTimeout(2000);
 	await page.mouse.move(startX, topDragY, { steps: 5 });
 	await page.mouse.up();
-	await page.waitForTimeout(500);
+	await page.waitForTimeout(1000);
 }
 
 async function visibleTodoOrder(page: Page) {
@@ -84,13 +84,15 @@ async function visibleTodoOrder(page: Page) {
 }
 
 async function visibleListMenuOrder(page: Page) {
-	return page.locator('.mdc-drawer .listContainer .item:not(#ghost)').evaluateAll((items) =>
-		items.map((item) => {
-			const clone = item.cloneNode(true) as HTMLElement;
-			clone.querySelectorAll('button').forEach((button) => button.remove());
-			return clone.textContent?.trim() || '';
-		})
-	);
+	return page
+		.locator('.mdc-drawer .listContainer .item:not(#ghost)')
+		.evaluateAll((items) =>
+			items.map((item) => {
+				const clone = item.cloneNode(true) as HTMLElement;
+				clone.querySelectorAll('button').forEach((button) => button.remove());
+				return clone.textContent?.trim() || '';
+			})
+		);
 }
 
 test('dragging a todo item to an off-screen list position autoscrolls the todo list', async ({
@@ -155,4 +157,22 @@ test('dragging a list to an off-screen list-menu position autoscrolls the list o
 	);
 
 	await expect.poll(async () => (await visibleListMenuOrder(page))[0]).toBe(listNames.at(-1));
+});
+
+test('clicking a list in the sidebar navigates to that list', async ({ page }) => {
+	await signIn(page);
+
+	const listName1 = `List One ${Date.now()}`;
+	const listName2 = `List Two ${Date.now()}`;
+
+	await createList(page, listName1);
+	await createList(page, listName2);
+
+	// Click on List One in the sidebar
+	const listOneRow = listMenuRow(page, listName1);
+	await listOneRow.click();
+
+	// Verify we are now on List One
+	await expect(page).toHaveURL(new RegExp(`lists\\?listId=`));
+	await expect(page.locator('.mdc-top-app-bar__title').filter({ hasText: listName1 })).toBeVisible();
 });

--- a/tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts
+++ b/tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts
@@ -1,0 +1,160 @@
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+const projectId = 'todo-firebase-1a740';
+
+test.beforeEach(async ({ request }, testInfo) => {
+	test.skip(testInfo.project.name !== 'Desktop Chrome', 'Desktop-only drag regression coverage.');
+
+	await request.delete(
+		`http://127.0.0.1:8080/emulator/v1/projects/${projectId}/databases/(default)/documents`
+	);
+	await request.delete(`http://127.0.0.1:9099/emulator/v1/projects/${projectId}/accounts`);
+});
+
+async function signIn(page: Page) {
+	await page.goto('/');
+	await page.getByRole('button', { name: 'Sign In', exact: true }).click();
+	await expect(page).toHaveURL(/\/profile/, { timeout: 10000 });
+}
+
+async function createList(page: Page, listName: string) {
+	await page.getByLabel('New list').fill(listName);
+	await page.keyboard.press('Enter');
+	await expect(page).toHaveURL(/lists\?listId=/, { timeout: 10000 });
+	await expect(page.locator('.mdc-top-app-bar__title').filter({ hasText: listName })).toBeVisible();
+}
+
+async function createTodoItems(page: Page, itemNames: string[]) {
+	const newTask = page.getByLabel('New task');
+	await expect(newTask).toBeVisible();
+	await page.waitForTimeout(800);
+	for (const [index, itemName] of [...itemNames].reverse().entries()) {
+		await newTask.fill(itemName);
+		await page.keyboard.press('Enter');
+		await expect(todoInputs(page)).toHaveCount(index + 1, { timeout: 10000 });
+	}
+}
+
+function todoRows(page: Page) {
+	return page.locator('.app-content .listContainer .item:not(#ghost)');
+}
+
+function todoInputs(page: Page) {
+	return page.locator('.app-content .listContainer .item:not(#ghost) input.description');
+}
+
+function listMenuRow(page: Page, listName: string) {
+	return page.locator('.mdc-drawer .listContainer .item:not(#ghost)').filter({ hasText: listName });
+}
+
+async function dragVisibleRowTowardTopOfViewport(
+	page: Page,
+	row: Locator,
+	scrollContainer: Locator,
+	topInset = 8
+) {
+	await row.scrollIntoViewIfNeeded();
+	const box = await row.boundingBox();
+	const scrollContainerBox = await scrollContainer.boundingBox();
+	if (!box) {
+		throw new Error('Cannot drag a row without a bounding box.');
+	}
+	if (!scrollContainerBox) {
+		throw new Error('Cannot drag toward a scroll container without a bounding box.');
+	}
+
+	const startX = box.x + Math.min(32, box.width / 2);
+	const startY = box.y + box.height / 2;
+	const topDragY = scrollContainerBox.y + topInset;
+
+	await page.mouse.move(startX, startY);
+	await page.mouse.down();
+	await page.waitForTimeout(150);
+	await page.mouse.move(startX, topDragY, { steps: 20 });
+	await page.waitForTimeout(1600);
+	await page.mouse.move(startX, topDragY, { steps: 5 });
+	await page.mouse.up();
+	await page.waitForTimeout(500);
+}
+
+async function visibleTodoOrder(page: Page) {
+	return todoInputs(page).evaluateAll((inputs) =>
+		inputs.map((input) => (input as HTMLInputElement).value)
+	);
+}
+
+async function visibleListMenuOrder(page: Page) {
+	return page
+		.locator('.mdc-drawer .listContainer .item:not(#ghost)')
+		.evaluateAll((items) =>
+			items.map((item) => {
+				const clone = item.cloneNode(true) as HTMLElement;
+				clone.querySelectorAll('button').forEach((button) => button.remove());
+				return clone.textContent?.trim() || '';
+			})
+		);
+}
+
+test('dragging a todo item to an off-screen list position autoscrolls the todo list', async ({
+	page
+}) => {
+	await signIn(page);
+
+	const listName = `Autoscroll todos ${Date.now()}`;
+	await createList(page, listName);
+
+	const itemNames = Array.from({ length: 30 }, (_, index) => {
+		return `Autoscroll todo ${String(index + 1).padStart(2, '0')}`;
+	});
+	await createTodoItems(page, itemNames);
+
+	await page.locator('.backdrop').evaluate((element) => {
+		element.scrollTop = element.scrollHeight;
+	});
+	const scrollTopBeforeDrag = await page
+		.locator('.backdrop')
+		.evaluate((element) => element.scrollTop);
+	await expect(todoRows(page).first()).not.toBeInViewport();
+	await expect(todoRows(page).last()).toBeInViewport();
+
+	await dragVisibleRowTowardTopOfViewport(
+		page,
+		todoRows(page).last(),
+		page.locator('.backdrop'),
+		64
+	);
+
+	await expect
+		.poll(async () => page.locator('.backdrop').evaluate((element) => element.scrollTop))
+		.toBeLessThan(scrollTopBeforeDrag);
+	await expect(todoRows(page).first()).toBeInViewport();
+});
+
+test('dragging a list to an off-screen list-menu position autoscrolls the list of lists', async ({
+	page
+}) => {
+	await signIn(page);
+
+	const listNames = Array.from({ length: 24 }, (_, index) => {
+		return `Autoscroll list ${String(index + 1).padStart(2, '0')} ${Date.now()}`;
+	});
+
+	for (const listName of listNames) {
+		await createList(page, listName);
+	}
+
+	const drawerContent = page.locator('.mdc-drawer > .mdc-drawer__content');
+	await drawerContent.evaluate((element) => {
+		element.scrollTop = element.scrollHeight;
+	});
+	await expect(listMenuRow(page, listNames[0])).not.toBeInViewport();
+	await expect(listMenuRow(page, listNames.at(-1) || '')).toBeInViewport();
+
+	await dragVisibleRowTowardTopOfViewport(
+		page,
+		listMenuRow(page, listNames.at(-1) || ''),
+		drawerContent
+	);
+
+	await expect.poll(async () => (await visibleListMenuOrder(page))[0]).toBe(listNames.at(-1));
+});

--- a/tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts
+++ b/tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts
@@ -84,15 +84,13 @@ async function visibleTodoOrder(page: Page) {
 }
 
 async function visibleListMenuOrder(page: Page) {
-	return page
-		.locator('.mdc-drawer .listContainer .item:not(#ghost)')
-		.evaluateAll((items) =>
-			items.map((item) => {
-				const clone = item.cloneNode(true) as HTMLElement;
-				clone.querySelectorAll('button').forEach((button) => button.remove());
-				return clone.textContent?.trim() || '';
-			})
-		);
+	return page.locator('.mdc-drawer .listContainer .item:not(#ghost)').evaluateAll((items) =>
+		items.map((item) => {
+			const clone = item.cloneNode(true) as HTMLElement;
+			clone.querySelectorAll('button').forEach((button) => button.remove());
+			return clone.textContent?.trim() || '';
+		})
+	);
 }
 
 test('dragging a todo item to an off-screen list position autoscrolls the todo list', async ({

--- a/tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts
+++ b/tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts
@@ -2,6 +2,8 @@ import { expect, type Locator, type Page, test } from '@playwright/test';
 
 const projectId = 'todo-firebase-1a740';
 
+test.describe.configure({ mode: 'serial' });
+
 test.beforeEach(async ({ request }, testInfo) => {
 	test.skip(testInfo.project.name !== 'Desktop Chrome', 'Desktop-only drag regression coverage.');
 
@@ -13,13 +15,17 @@ test.beforeEach(async ({ request }, testInfo) => {
 
 async function signIn(page: Page) {
 	await page.goto('/');
+	await page.addStyleTag({
+		content: '.firebase-emulator-warning { display: none !important; }'
+	});
 	await page.getByRole('button', { name: 'Sign In', exact: true }).click();
-	await expect(page).toHaveURL(/\/profile/, { timeout: 10000 });
+	await expect(page.getByLabel('New list')).toBeVisible({ timeout: 15000 });
 }
 
 async function createList(page: Page, listName: string) {
-	await page.getByLabel('New list').fill(listName);
-	await page.keyboard.press('Enter');
+	const newList = page.getByLabel('New list');
+	await newList.fill(listName);
+	await newList.press('Enter');
 	await expect(page).toHaveURL(/lists\?listId=/, { timeout: 10000 });
 	await expect(page.locator('.mdc-top-app-bar__title').filter({ hasText: listName })).toBeVisible();
 }
@@ -28,11 +34,13 @@ async function createTodoItems(page: Page, itemNames: string[]) {
 	const newTask = page.getByLabel('New task');
 	await expect(newTask).toBeVisible();
 	await page.waitForTimeout(1500);
-	for (const [index, itemName] of [...itemNames].reverse().entries()) {
+	for (const itemName of [...itemNames].reverse()) {
 		await newTask.fill(itemName);
-		await page.keyboard.press('Enter');
-		await expect(todoInputs(page)).toHaveCount(index + 1, { timeout: 15000 });
+		await newTask.press('Enter');
+		await expect.poll(async () => visibleTodoOrder(page), { timeout: 15000 }).toContain(itemName);
+		await expect(newTask).toHaveValue('');
 	}
+	await expect(todoInputs(page)).toHaveCount(itemNames.length, { timeout: 15000 });
 }
 
 function todoRows(page: Page) {
@@ -63,13 +71,13 @@ async function dragVisibleRowTowardTopOfViewport(
 		throw new Error('Cannot drag toward a scroll container without a bounding box.');
 	}
 
-	const startX = box.x + Math.min(32, box.width / 2);
+	const startX = box.x + box.width / 2;
 	const startY = box.y + box.height / 2;
 	const topDragY = scrollContainerBox.y + topInset;
 
 	await page.mouse.move(startX, startY);
 	await page.mouse.down();
-	await page.waitForTimeout(500);
+	await expect(row).toHaveAttribute('id', 'grabbed', { timeout: 1500 });
 	await page.mouse.move(startX, topDragY, { steps: 20 });
 	await page.waitForTimeout(2000);
 	await page.mouse.move(startX, topDragY, { steps: 5 });

--- a/tests/e2e/helpers/test-step-helper.ts
+++ b/tests/e2e/helpers/test-step-helper.ts
@@ -3,120 +3,127 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 interface Verification {
-  spec: string;
-  check: () => Promise<void>;
+	spec: string;
+	check: () => Promise<void>;
 }
 
 interface StepOptions {
-  description?: string;
-  verifications?: Verification[];
+	description?: string;
+	verifications?: Verification[];
 }
 
 export class TestStepHelper {
-  private page: Page;
-  private testInfo: TestInfo;
-  private scenarioName: string = '';
-  private scenarioDescription: string = '';
-  private steps: { name: string; description: string; screenshot: string; verifications: string[] }[] = [];
-  private stepCount: number = 0;
+	private page: Page;
+	private testInfo: TestInfo;
+	private scenarioName: string = '';
+	private scenarioDescription: string = '';
+	private steps: {
+		name: string;
+		description: string;
+		screenshot: string;
+		verifications: string[];
+	}[] = [];
+	private stepCount: number = 0;
 
-  constructor(page: Page, testInfo: TestInfo) {
-    this.page = page;
-    this.testInfo = testInfo;
-  }
+	constructor(page: Page, testInfo: TestInfo) {
+		this.page = page;
+		this.testInfo = testInfo;
+	}
 
-  setMetadata(name: string, description: string) {
-    this.scenarioName = name;
-    this.scenarioDescription = description;
+	setMetadata(name: string, description: string) {
+		this.scenarioName = name;
+		this.scenarioDescription = description;
 
-    const specDir = path.dirname(this.testInfo.file);
-    const screenshotDir = path.join(specDir, 'screenshots');
-    const readmePath = path.join(specDir, 'README.md');
+		const specDir = path.dirname(this.testInfo.file);
+		const screenshotDir = path.join(specDir, 'screenshots');
+		const readmePath = path.join(specDir, 'README.md');
 
-    if (fs.existsSync(screenshotDir)) {
-      fs.rmSync(screenshotDir, { recursive: true, force: true });
-    }
-    if (fs.existsSync(readmePath)) {
-      fs.rmSync(readmePath, { force: true });
-    }
-  }
+		if (fs.existsSync(screenshotDir)) {
+			fs.rmSync(screenshotDir, { recursive: true, force: true });
+		}
+		if (fs.existsSync(readmePath)) {
+			fs.rmSync(readmePath, { force: true });
+		}
+	}
 
-  /**
-   * Waits for all active CSS animations and transitions to finish.
-   */
-  async waitForAnimations() {
-    await this.page.evaluate(async () => {
-      const animations = document.getAnimations();
-      await Promise.allSettled(animations.map(a => a.finished));
-    });
-  }
+	/**
+	 * Waits for all active CSS animations and transitions to finish.
+	 */
+	async waitForAnimations() {
+		await this.page.evaluate(async () => {
+			const animations = document.getAnimations();
+			await Promise.allSettled(animations.map((a) => a.finished));
+		});
+	}
 
-  /**
-   * Performs an atomic test step: verifications, waiting for animations, and capturing a screenshot.
-   */
-  async step(name: string, options: StepOptions = {}) {
-    this.stepCount++;
-    const stepNumber = String(this.stepCount).padStart(3, '0');
-    const safeName = name.replace(/[^a-z0-9]/gi, '-').toLowerCase();
-    const screenshotName = `${stepNumber}-${safeName}.png`;
-    
-    // Perform verifications
-    const verificationResults: string[] = [];
-    if (options.verifications) {
-      for (const v of options.verifications) {
-        await v.check();
-        verificationResults.push(v.spec);
-      }
-    }
+	/**
+	 * Performs an atomic test step: verifications, waiting for animations, and capturing a screenshot.
+	 */
+	async step(name: string, options: StepOptions = {}) {
+		this.stepCount++;
+		const stepNumber = String(this.stepCount).padStart(3, '0');
+		const safeName = name.replace(/[^a-z0-9]/gi, '-').toLowerCase();
+		const screenshotName = `${stepNumber}-${safeName}.png`;
 
-    await this.waitForAnimations();
+		// Perform verifications
+		const verificationResults: string[] = [];
+		if (options.verifications) {
+			for (const v of options.verifications) {
+				await v.check();
+				verificationResults.push(v.spec);
+			}
+		}
 
-    const specDir = path.dirname(this.testInfo.file);
-    const screenshotDir = path.join(specDir, 'screenshots');
-    
-    if (!fs.existsSync(screenshotDir)) {
-      fs.mkdirSync(screenshotDir, { recursive: true });
-    }
+		await this.waitForAnimations();
 
-    const screenshotPath = path.join(screenshotDir, screenshotName);
-    
-    // We use fullPage: true to ensure we capture everything, as per the guide's philosophy.
-    await this.page.screenshot({ path: screenshotPath, fullPage: true });
+		const specDir = path.dirname(this.testInfo.file);
+		const screenshotDir = path.join(specDir, 'screenshots');
 
-    this.steps.push({
-      name,
-      description: options.description || '',
-      screenshot: `screenshots/${screenshotName}`,
-      verifications: verificationResults
-    });
-  }
+		if (!fs.existsSync(screenshotDir)) {
+			fs.mkdirSync(screenshotDir, { recursive: true });
+		}
 
-  /**
-   * Generates a README.md file in the scenario directory documenting the steps and results.
-   */
-  async generateDocs() {
-    const specDir = path.dirname(this.testInfo.file);
-    const readmePath = path.join(specDir, 'README.md');
+		const screenshotPath = path.join(screenshotDir, screenshotName);
 
-    let content = `# Scenario: ${this.scenarioName}\n\n`;
-    content += `${this.scenarioDescription}\n\n`;
-    content += `## Steps\n\n`;
+		// We use fullPage: true to ensure we capture everything, as per the guide's philosophy.
+		await this.page.screenshot({ path: screenshotPath, fullPage: true });
 
-    for (const step of this.steps) {
-      content += `### Step ${String(this.steps.indexOf(step) + 1).padStart(3, '0')}: ${step.name}\n\n`;
-      if (step.description) {
-        content += `${step.description}\n\n`;
-      }
-      if (step.verifications.length > 0) {
-        content += `**Verifications:**\n`;
-        for (const v of step.verifications) {
-          content += `- [x] ${v}\n`;
-        }
-        content += `\n`;
-      }
-      content += `![${step.name}](${step.screenshot})\n\n`;
-    }
+		this.steps.push({
+			name,
+			description: options.description || '',
+			screenshot: `screenshots/${screenshotName}`,
+			verifications: verificationResults
+		});
+	}
 
-    fs.writeFileSync(readmePath, content);
-  }
+	/**
+	 * Generates a README.md file in the scenario directory documenting the steps and results.
+	 */
+	async generateDocs() {
+		const specDir = path.dirname(this.testInfo.file);
+		const readmePath = path.join(specDir, 'README.md');
+
+		let content = `# Scenario: ${this.scenarioName}\n\n`;
+		content += `${this.scenarioDescription}\n\n`;
+		content += `## Steps\n\n`;
+
+		for (const step of this.steps) {
+			content += `### Step ${String(this.steps.indexOf(step) + 1).padStart(3, '0')}: ${
+				step.name
+			}\n\n`;
+			if (step.description) {
+				content += `${step.description}\n\n`;
+			}
+			if (step.verifications.length > 0) {
+				content += `**Verifications:**\n`;
+				for (const v of step.verifications) {
+					content += `- [x] ${v}\n`;
+				}
+				content += `\n`;
+			}
+			content += `![${step.name}](${step.screenshot})\n\n`;
+		}
+
+		fs.writeFileSync(readmePath, content);
+	}
 }


### PR DESCRIPTION
Implement autoscrolling when dragging items or lists to the edges of the viewport.

Changes:
- Added a reusable `createDragAutoScroller` utility in `src/lib/components/autoscroll.ts`.
- Integrated autoscrolling into `ItemList.svelte` and `ListMenu.svelte`.
- Improved drag target detection when scrolling.
- Added E2E tests in `tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts`.
- Updated `flake.nix` to include `jdk17` for running Firebase emulators locally.