### PR TITLE
[codex] Add E2E guide and isolated runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ playwright-report/
 test-results/
 worktrees/
 firestore-backups/
+.e2e/

--- a/E2E_GUIDE.md
+++ b/E2E_GUIDE.md
@@ -1,0 +1,93 @@
+# E2E Testing Guide
+
+This project uses [Playwright](https://playwright.dev/) for End-to-End testing. Our E2E tests are the primary source of truth for application correctness.
+
+## 1. The Philosophy: "Zero-Pixel Tolerance"
+
+We enforce a strict **Zero-Pixel Tolerance** policy for visual regression. Since visual state is the primary feedback mechanism for the user, any deviation is considered a bug.
+
+- **Software Rendering**: Tests should use deterministic browser and rendering settings so snapshots are consistent across CI and local environments.
+- **Determinism**: Tests must be deterministic. Random seeds must be fixed, Firebase emulator state must be reset, and tests should avoid depending on existing user data.
+
+## 2. Test Structure
+
+All E2E tests live in `tests/e2e/`. Each test case gets its own directory.
+
+```text
+tests/e2e/
+├── helpers/                   # Shared utilities (TestStepHelper)
+├── 001-login/                 # Scenario directory
+│   ├── 001-login.spec.ts      # Main test file
+│   ├── README.md              # Auto-generated verification doc
+│   └── screenshots/           # Committed baseline images
+```
+
+## 3. The "Unified Step Pattern"
+
+To prevent synchronization errors between documentation and screenshots, we use a **Unified Step API**. You must **NEVER** manually manage filenames or counters.
+
+### The `TestStepHelper`
+
+We use `TestStepHelper` from `tests/e2e/helpers/test-step-helper.ts` to combine documentation, verification, and screenshot capture into a single atomic operation: `step()`.
+
+#### Usage
+
+```typescript
+import { test, expect } from '@playwright/test';
+import { TestStepHelper } from '../helpers/test-step-helper';
+
+test('user creates a todo list', async ({ page }, testInfo) => {
+	const helper = new TestStepHelper(page, testInfo);
+	helper.setMetadata('Create Todo List', 'Verify that a signed-in user can create a list.');
+
+	await page.goto('/');
+	await helper.step('login_page', {
+		description: 'User is redirected to the login page.',
+		verifications: [
+			{
+				spec: 'Login button is visible',
+				check: async () =>
+					expect(page.getByRole('button', { name: 'Sign In', exact: true })).toBeVisible()
+			}
+		]
+	});
+
+	await helper.generateDocs();
+});
+```
+
+This automatically:
+
+1. Generates numbered screenshots, such as `001-login-page.png`.
+2. Runs verifications before capturing the screenshot.
+3. Waits for active animations and transitions before capture.
+4. Generates a scenario `README.md` for the test run.
+
+## 4. Playwright Configuration
+
+- **Command**: Run E2E tests with `npm run playwright`.
+- **Browsers**: Tests run against Desktop Chrome and Pixel 5 projects.
+- **App server**: Playwright builds the app and serves it through `npm run preview`.
+- **Emulators**: Playwright starts the Firebase Firestore and Auth emulators for E2E runs.
+- **Timeouts**: Prefer short, condition-based waits in individual steps. Use longer timeouts only for app startup, emulator startup, login redirects, or other explicitly slow flows.
+- **Waits**: `waitForTimeout` and other arbitrary waits are not allowed; always wait on real UI conditions like `expect().toBeVisible()`, `expect().toHaveURL()`, or `waitForSelector()`.
+
+## 5. Worktree-Safe E2E Runs
+
+Agents and developers working in separate worktrees must run E2E tests through the Nix dev shell:
+
+```sh
+nix develop -c npm run playwright:isolated
+```
+
+This command derives a stable port block from the current worktree path, generates `.e2e/firebase.json`, and runs Playwright with isolated app, Firestore, Auth, Firebase UI, and Firebase hub ports. It also uses a worktree-specific Firebase project ID such as `todo-e2e-<hash>` so emulator resets do not touch another worktree's data.
+
+Do not run broad cleanup commands such as `pkill firebase`, `killall firebase`, or `lsof -ti :8080 | xargs kill` while other agents may be working. Isolated Playwright runs should only manage their own child processes.
+
+If a specific port block is needed, set `E2E_PORT_BASE` before running the isolated command:
+
+```sh
+E2E_PORT_BASE=43100 nix develop -c npm run playwright:isolated
+```
+
+The generated `.e2e/` directory is local scratch state and must not be committed.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"preview": "vite preview",
 		"test": "vitest run --coverage",
 		"playwright": "playwright test",
+		"playwright:isolated": "node scripts/playwright-isolated.mjs",
 		"deploy": "scripts/deploy-production.sh",
 		"deploy:preflight": "scripts/check-firebase-deploy-sa.sh"
 	},

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,24 +1,39 @@
 import { devices, type PlaywrightTestConfig } from '@playwright/test';
 
+const appPort = process.env.E2E_APP_PORT || '4173';
+const firebaseConfig = process.env.E2E_FIREBASE_CONFIG || 'firebase.json';
+const firebaseProjectId = process.env.E2E_FIREBASE_PROJECT_ID || 'todo-firebase-1a740';
+const firestoreEmulatorHost = process.env.E2E_FIRESTORE_EMULATOR_HOST || '127.0.0.1';
+const firestoreEmulatorPort = process.env.E2E_FIRESTORE_EMULATOR_PORT || '8080';
+const authEmulatorHost = process.env.E2E_AUTH_EMULATOR_HOST || '127.0.0.1';
+const authEmulatorPort = process.env.E2E_AUTH_EMULATOR_PORT || '9099';
+const reuseExistingServer = process.env.E2E_ISOLATED !== 'true';
+const shellArg = (value: string) => `'${value.replace(/'/g, `'\\''`)}'`;
+
 const config: PlaywrightTestConfig = {
 	webServer: [
 		{
-			command: 'npm run build && npm run preview -- --host 127.0.0.1',
-			url: 'http://127.0.0.1:4173',
+			command: `npm run build && npm run preview -- --host 127.0.0.1 --port ${appPort}`,
+			url: `http://127.0.0.1:${appPort}`,
 			env: {
 				VITE_USE_FIREBASE_EMULATOR: 'true',
+				VITE_FIREBASE_PROJECT_ID: firebaseProjectId,
+				VITE_FIRESTORE_EMULATOR_HOST: firestoreEmulatorHost,
+				VITE_FIRESTORE_EMULATOR_PORT: firestoreEmulatorPort,
+				VITE_AUTH_EMULATOR_URL: `http://${authEmulatorHost}:${authEmulatorPort}`,
 				VITE_TEST_LOGIN_EMAIL: process.env.VITE_TEST_LOGIN_EMAIL || '',
 				VITE_TEST_LOGIN_PASSWORD: process.env.VITE_TEST_LOGIN_PASSWORD || '',
 				VITE_TEST_LOGIN_NAME: process.env.VITE_TEST_LOGIN_NAME || ''
 			},
-			reuseExistingServer: true,
+			reuseExistingServer,
 			timeout: 120000
 		},
 		{
-			command:
-				'npx firebase emulators:start --only firestore,auth --project todo-firebase-1a740 --non-interactive',
-			url: 'http://127.0.0.1:9099',
-			reuseExistingServer: true,
+			command: `npx firebase emulators:start --config ${shellArg(
+				firebaseConfig
+			)} --only firestore,auth --project ${shellArg(firebaseProjectId)} --non-interactive`,
+			url: `http://${authEmulatorHost}:${authEmulatorPort}`,
+			reuseExistingServer,
 			timeout: 120000
 		}
 	],
@@ -26,7 +41,7 @@ const config: PlaywrightTestConfig = {
 	timeout: 60000,
 	workers: process.env.CI ? 1 : undefined,
 	use: {
-		baseURL: 'http://127.0.0.1:4173',
+		baseURL: `http://127.0.0.1:${appPort}`,
 		trace: 'on-first-retry'
 	},
 	reporter: process.env.CI ? 'html' : 'list',

--- a/scripts/firestore-copy.mjs
+++ b/scripts/firestore-copy.mjs
@@ -8,8 +8,12 @@ const FIREBASE_CLIENT_ID =
 const FIREBASE_CLIENT_SECRET = 'j9iVZfS8kkCEFUPaAeJV0sAi';
 const projectId = process.env.FIREBASE_PROJECT_ID || 'todo-firebase-1a740';
 const databaseId = process.env.FIRESTORE_DATABASE_ID || '(default)';
+const firestoreEmulatorHost = (process.env.FIRESTORE_EMULATOR_HOST || '127.0.0.1:8080').replace(
+	/^https?:\/\//,
+	''
+);
 const firestoreBase = `https://firestore.googleapis.com/v1/projects/${projectId}/databases/${databaseId}/documents`;
-const emulatorBase = `http://127.0.0.1:8080/v1/projects/${projectId}/databases/${databaseId}/documents`;
+const emulatorBase = `http://${firestoreEmulatorHost}/v1/projects/${projectId}/databases/${databaseId}/documents`;
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function readFirebaseCliTokens() {

--- a/scripts/playwright-isolated.mjs
+++ b/scripts/playwright-isolated.mjs
@@ -1,0 +1,116 @@
+import { spawnSync, execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function gitTopLevel() {
+	try {
+		return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'ignore']
+		}).trim();
+	} catch {
+		return process.cwd();
+	}
+}
+
+function portBaseForWorktree(worktreePath) {
+	if (process.env.E2E_PORT_BASE) {
+		const portBase = Number(process.env.E2E_PORT_BASE);
+		if (!Number.isInteger(portBase) || portBase < 1024 || portBase > 65530) {
+			throw new Error(`E2E_PORT_BASE must be an integer from 1024 to 65530: ${portBase}`);
+		}
+		return portBase;
+	}
+
+	const hash = createHash('sha256').update(worktreePath).digest('hex');
+	const bucket = Number.parseInt(hash.slice(0, 8), 16) % 2000;
+	return 30000 + bucket * 10;
+}
+
+const worktreePath = gitTopLevel();
+const hash = createHash('sha256').update(worktreePath).digest('hex').slice(0, 8);
+const portBase = portBaseForWorktree(worktreePath);
+const host = '127.0.0.1';
+const ports = {
+	app: portBase,
+	firestore: portBase + 1,
+	auth: portBase + 2,
+	ui: portBase + 3,
+	hub: portBase + 4
+};
+const projectId = process.env.E2E_FIREBASE_PROJECT_ID || `todo-e2e-${hash}`;
+const e2eDir = path.join(worktreePath, '.e2e');
+const firebaseConfigPath = path.join(e2eDir, 'firebase.json');
+
+fs.mkdirSync(e2eDir, { recursive: true });
+fs.writeFileSync(
+	firebaseConfigPath,
+	`${JSON.stringify(
+		{
+			firestore: {
+				rules: 'firestore.rules',
+				indexes: 'firestore.indexes.json'
+			},
+			emulators: {
+				auth: {
+					host,
+					port: ports.auth
+				},
+				firestore: {
+					host,
+					port: ports.firestore
+				},
+				ui: {
+					enabled: true,
+					host,
+					port: ports.ui
+				},
+				hub: {
+					host,
+					port: ports.hub
+				},
+				singleProjectMode: true
+			}
+		},
+		null,
+		2
+	)}\n`
+);
+
+const env = {
+	...process.env,
+	E2E_ISOLATED: 'true',
+	E2E_APP_PORT: String(ports.app),
+	E2E_FIREBASE_CONFIG: firebaseConfigPath,
+	E2E_FIREBASE_PROJECT_ID: projectId,
+	E2E_FIRESTORE_EMULATOR_HOST: host,
+	E2E_FIRESTORE_EMULATOR_PORT: String(ports.firestore),
+	E2E_AUTH_EMULATOR_HOST: host,
+	E2E_AUTH_EMULATOR_PORT: String(ports.auth),
+	E2E_FIREBASE_UI_PORT: String(ports.ui),
+	E2E_FIREBASE_HUB_PORT: String(ports.hub),
+	FIREBASE_PROJECT_ID: projectId,
+	FIRESTORE_EMULATOR_HOST: `${host}:${ports.firestore}`,
+	VITE_FIREBASE_PROJECT_ID: projectId,
+	VITE_FIRESTORE_EMULATOR_HOST: host,
+	VITE_FIRESTORE_EMULATOR_PORT: String(ports.firestore),
+	VITE_AUTH_EMULATOR_URL: `http://${host}:${ports.auth}`
+};
+
+console.log(
+	[
+		`E2E worktree: ${worktreePath}`,
+		`E2E project: ${projectId}`,
+		`E2E ports: app=${ports.app}, firestore=${ports.firestore}, auth=${ports.auth}, ui=${ports.ui}, hub=${ports.hub}`
+	].join('\n')
+);
+
+const args = process.argv.slice(2);
+const result = spawnSync('npx', ['playwright', 'test', ...args], {
+	cwd: worktreePath,
+	env,
+	stdio: 'inherit'
+});
+
+process.exit(result.status ?? 1);

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -23,11 +23,12 @@ import { Capacitor } from '@capacitor/core';
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 
 // This config is repeated in static/firebase-config.js
+const firebaseProjectId = import.meta.env.VITE_FIREBASE_PROJECT_ID || 'todo-firebase-1a740';
 const firebaseConfig = {
 	apiKey: 'AIzaSyC7mMXhf0noyZ-0LTJwyRJLpJlX6b-7MqQ',
-	authDomain: 'todo-firebase-1a740.firebaseapp.com',
-	projectId: 'todo-firebase-1a740',
-	storageBucket: 'todo-firebase-1a740.appspot.com',
+	authDomain: `${firebaseProjectId}.firebaseapp.com`,
+	projectId: firebaseProjectId,
+	storageBucket: `${firebaseProjectId}.appspot.com`,
 	messagingSenderId: '847898271389',
 	appId: '1:847898271389:web:d386e542429c9bd9033e74',
 	measurementId: 'G-TM8YJTC4SX'
@@ -96,11 +97,14 @@ const useFirestoreEmulator =
 const useAuthEmulator = useFirebaseEmulator || import.meta.env.VITE_USE_AUTH_EMULATOR === 'true';
 
 if (useFirestoreEmulator) {
-	connectFirestoreEmulator(firebase.firestore, '127.0.0.1', 8080);
+	const firestoreEmulatorHost = import.meta.env.VITE_FIRESTORE_EMULATOR_HOST || '127.0.0.1';
+	const firestoreEmulatorPort = Number(import.meta.env.VITE_FIRESTORE_EMULATOR_PORT || 8080);
+	connectFirestoreEmulator(firebase.firestore, firestoreEmulatorHost, firestoreEmulatorPort);
 }
 
 if (useAuthEmulator) {
-	connectAuthEmulator(firebase.auth, 'http://127.0.0.1:9099');
+	const authEmulatorUrl = import.meta.env.VITE_AUTH_EMULATOR_URL || 'http://127.0.0.1:9099';
+	connectAuthEmulator(firebase.auth, authEmulatorUrl);
 }
 
 if (import.meta.env.VITE_DISABLE_FIRESTORE_PERSISTENCE !== 'true') {

--- a/tests/e2e/001-login/001-login.spec.ts
+++ b/tests/e2e/001-login/001-login.spec.ts
@@ -1,12 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { TestStepHelper } from '../helpers/test-step-helper';
+import { resetFirestoreEmulator } from '../helpers/emulator';
 
 test.beforeEach(async ({ request }) => {
 	// Ensure that the E2E tests start with a clean state in the emulator.
-	const projectId = 'todo-firebase-1a740';
-	await request.delete(
-		`http://127.0.0.1:8080/emulator/v1/projects/${projectId}/databases/(default)/documents`
-	);
+	await resetFirestoreEmulator(request);
 });
 
 test('login page verification', async ({ page }, testInfo) => {

--- a/tests/e2e/002-auth-flow/002-auth-flow.spec.ts
+++ b/tests/e2e/002-auth-flow/002-auth-flow.spec.ts
@@ -1,17 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { TestStepHelper } from '../helpers/test-step-helper';
+import { resetEmulators } from '../helpers/emulator';
 
 test.beforeEach(async ({ request }) => {
 	// Ensure that the E2E tests start with a clean state in the emulator.
-	const projectId = 'todo-firebase-1a740';
-	await request.delete(
-		`http://127.0.0.1:8080/emulator/v1/projects/${projectId}/databases/(default)/documents`
-	);
-
-	// Optional: Clear Auth users if possible.
-	// The Firebase Auth emulator has a REST API for this:
-	// DELETE http://127.0.0.1:9099/emulator/v1/projects/{project-id}/accounts
-	await request.delete(`http://127.0.0.1:9099/emulator/v1/projects/${projectId}/accounts`);
+	await resetEmulators(request);
 });
 
 test('successful login and profile view', async ({ page }, testInfo) => {

--- a/tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts
+++ b/tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts
@@ -1,16 +1,12 @@
 import { expect, type Locator, type Page, test } from '@playwright/test';
-
-const projectId = 'todo-firebase-1a740';
+import { resetEmulators } from '../helpers/emulator';
 
 test.describe.configure({ mode: 'serial' });
 
 test.beforeEach(async ({ request }, testInfo) => {
 	test.skip(testInfo.project.name !== 'Desktop Chrome', 'Desktop-only drag regression coverage.');
 
-	await request.delete(
-		`http://127.0.0.1:8080/emulator/v1/projects/${projectId}/databases/(default)/documents`
-	);
-	await request.delete(`http://127.0.0.1:9099/emulator/v1/projects/${projectId}/accounts`);
+	await resetEmulators(request);
 });
 
 async function signIn(page: Page) {
@@ -92,15 +88,13 @@ async function visibleTodoOrder(page: Page) {
 }
 
 async function visibleListMenuOrder(page: Page) {
-	return page
-		.locator('.mdc-drawer .listContainer .item:not(#ghost)')
-		.evaluateAll((items) =>
-			items.map((item) => {
-				const clone = item.cloneNode(true) as HTMLElement;
-				clone.querySelectorAll('button').forEach((button) => button.remove());
-				return clone.textContent?.trim() || '';
-			})
-		);
+	return page.locator('.mdc-drawer .listContainer .item:not(#ghost)').evaluateAll((items) =>
+		items.map((item) => {
+			const clone = item.cloneNode(true) as HTMLElement;
+			clone.querySelectorAll('button').forEach((button) => button.remove());
+			return clone.textContent?.trim() || '';
+		})
+	);
 }
 
 test('dragging a todo item to an off-screen list position autoscrolls the todo list', async ({
@@ -182,5 +176,7 @@ test('clicking a list in the sidebar navigates to that list', async ({ page }) =
 
 	// Verify we are now on List One
 	await expect(page).toHaveURL(new RegExp(`lists\\?listId=`));
-	await expect(page.locator('.mdc-top-app-bar__title').filter({ hasText: listName1 })).toBeVisible();
+	await expect(
+		page.locator('.mdc-top-app-bar__title').filter({ hasText: listName1 })
+	).toBeVisible();
 });

--- a/tests/e2e/004-andrew-load/004-andrew-load.spec.ts
+++ b/tests/e2e/004-andrew-load/004-andrew-load.spec.ts
@@ -2,8 +2,13 @@ import { expect, test, type Page } from '@playwright/test';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+	authEmulatorOrigin,
+	emulatorProjectId,
+	resetAuthEmulator,
+	resetFirestoreEmulator
+} from '../helpers/emulator';
 
-const projectId = 'todo-firebase-1a740';
 const backupPath = process.env.ANDREW_LOAD_BACKUP;
 const maxLoadMs = Number(process.env.ANDREW_LOAD_MAX_MS || 120000);
 const shouldResetFirestore = process.env.ANDREW_LOAD_RESET_FIRESTORE === 'true';
@@ -32,12 +37,9 @@ test.beforeEach(async ({ request }, testInfo) => {
 	}
 
 	if (shouldResetFirestore) {
-		await request.delete(
-			`http://127.0.0.1:8080/emulator/v1/projects/${projectId}/databases/(default)/documents`,
-			{ timeout: 180000 }
-		);
+		await resetFirestoreEmulator(request, { timeout: 180000 });
 	}
-	await request.delete(`http://127.0.0.1:9099/emulator/v1/projects/${projectId}/accounts`);
+	await resetAuthEmulator(request);
 
 	if (shouldSeedFirestore) {
 		execFileSync(process.execPath, ['scripts/firestore-copy.mjs', 'seed', resolvedBackupPath], {
@@ -47,7 +49,7 @@ test.beforeEach(async ({ request }, testInfo) => {
 	}
 
 	const response = await request.post(
-		`http://127.0.0.1:9099/identitytoolkit.googleapis.com/v1/projects/${projectId}/accounts:batchCreate?key=fake-api-key`,
+		`${authEmulatorOrigin}/identitytoolkit.googleapis.com/v1/projects/${emulatorProjectId}/accounts:batchCreate?key=fake-api-key`,
 		{
 			headers: {
 				authorization: 'Bearer owner'

--- a/tests/e2e/helpers/emulator.ts
+++ b/tests/e2e/helpers/emulator.ts
@@ -1,0 +1,33 @@
+import type { APIRequestContext } from '@playwright/test';
+
+type DeleteOptions = Parameters<APIRequestContext['delete']>[1];
+
+export const emulatorProjectId =
+	process.env.E2E_FIREBASE_PROJECT_ID || process.env.FIREBASE_PROJECT_ID || 'todo-firebase-1a740';
+
+const firestoreHost = process.env.E2E_FIRESTORE_EMULATOR_HOST || '127.0.0.1';
+const firestorePort = process.env.E2E_FIRESTORE_EMULATOR_PORT || '8080';
+const authHost = process.env.E2E_AUTH_EMULATOR_HOST || '127.0.0.1';
+const authPort = process.env.E2E_AUTH_EMULATOR_PORT || '9099';
+
+export const firestoreEmulatorOrigin = `http://${firestoreHost}:${firestorePort}`;
+export const authEmulatorOrigin = `http://${authHost}:${authPort}`;
+
+export async function resetFirestoreEmulator(request: APIRequestContext, options?: DeleteOptions) {
+	await request.delete(
+		`${firestoreEmulatorOrigin}/emulator/v1/projects/${emulatorProjectId}/databases/(default)/documents`,
+		options
+	);
+}
+
+export async function resetAuthEmulator(request: APIRequestContext, options?: DeleteOptions) {
+	await request.delete(
+		`${authEmulatorOrigin}/emulator/v1/projects/${emulatorProjectId}/accounts`,
+		options
+	);
+}
+
+export async function resetEmulators(request: APIRequestContext) {
+	await resetFirestoreEmulator(request);
+	await resetAuthEmulator(request);
+}


### PR DESCRIPTION
## Summary

Adds a root `E2E_GUIDE.md` adapted from `anicolao/food` for this Todo project and documents the existing unified `TestStepHelper` pattern.

Adds a worktree-safe E2E runner:

- `npm run playwright:isolated` derives a stable per-worktree port block and Firebase project ID.
- The runner generates ignored `.e2e/firebase.json` with isolated Firestore, Auth, UI, and hub ports.
- `playwright.config.ts` now reads E2E port/project env vars while preserving existing defaults for `npm run playwright`.
- App Firebase emulator connection and E2E reset/seeding helpers now use the same env-derived ports/project ID.
- The guide instructs agents/developers to run isolated E2E through `nix develop -c npm run playwright:isolated` and avoid broad emulator cleanup commands.

I reviewed `tests/e2e/helpers/test-step-helper.ts` and did not change it. It already resets scenario artifacts, runs verifications before screenshots, waits for animations, captures numbered full-page screenshots, and writes the scenario README.

## Validation

Run through the project flake:

- `nix develop -c npx prettier --check --ignore-unknown .gitignore E2E_GUIDE.md package.json playwright.config.ts scripts/playwright-isolated.mjs scripts/firestore-copy.mjs src/lib/firebase.ts tests/e2e/helpers/emulator.ts tests/e2e/001-login/001-login.spec.ts tests/e2e/002-auth-flow/002-auth-flow.spec.ts tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts tests/e2e/004-andrew-load/004-andrew-load.spec.ts`
- `nix develop -c npx tsc --noEmit --skipLibCheck --module ESNext --moduleResolution Bundler --target ES2020 --types node playwright.config.ts tests/e2e/helpers/test-step-helper.ts tests/e2e/helpers/emulator.ts tests/e2e/001-login/001-login.spec.ts tests/e2e/002-auth-flow/002-auth-flow.spec.ts tests/e2e/003-autoscroll-drag/003-autoscroll-drag.spec.ts tests/e2e/004-andrew-load/004-andrew-load.spec.ts`
- `nix develop -c node --check scripts/playwright-isolated.mjs`
- `nix develop -c npm run playwright:isolated -- tests/e2e/001-login/001-login.spec.ts --project "Desktop Chrome"`

`nix develop -c npm run check` was also attempted, but it fails in existing dependency code under `node_modules/@smui/menu/src/SelectionGroupIcon.ts` with a Svelte construct signature compatibility error, outside this change.